### PR TITLE
Updated to allow async validation rules

### DIFF
--- a/samples/ServerSideBlazor/Pages/Index.razor
+++ b/samples/ServerSideBlazor/Pages/Index.razor
@@ -9,16 +9,19 @@
     <p>
         <label>Name: </label>
         <InputText @bind-Value="@Person.Name" />
+        <ValidationMessage For="@(() => Person.Name)" />
     </p>
 
     <p>
         <label>Age: </label>
         <InputNumber @bind-Value="@Person.Age" />
+        <ValidationMessage For="@(() => Person.Age)" />
     </p>
 
     <p>
         <label>Email Address: </label>
         <InputText @bind-Value="@Person.EmailAddress" />
+        <ValidationMessage For="@(() => Person.EmailAddress)" />
     </p>
 
     <button type="submit">Save</button>

--- a/samples/Shared/SharedModels/Person.cs
+++ b/samples/Shared/SharedModels/Person.cs
@@ -14,6 +14,7 @@ namespace SharedModel
     {
         public PersonValidator()
         {
+            RuleFor(p => p.Name).NotEmpty().WithMessage("You must enter a name");
             RuleFor(p => p.Name).MaximumLength(50).WithMessage("Name cannot be longer than 50 characters");
             RuleFor(p => p.Age).NotEmpty().WithMessage("Age must be greater than 0");
             RuleFor(p => p.Age).LessThan(150).WithMessage("Age cannot be greater than 150");
@@ -21,13 +22,14 @@ namespace SharedModel
             RuleFor(p => p.EmailAddress).EmailAddress().WithMessage("You must provide a valid email address");
 
             RuleFor(x => x.Name).MustAsync(async (name, cancellationToken) => await IsUniqueAsync(name))
-                    .WithMessage("Name must be unique");
+                                .WithMessage("Name must be unique")
+                                .When(person => !string.IsNullOrEmpty(person.Name));
         }
 
         private async Task<bool> IsUniqueAsync(string name)
         {
-            await Task.Delay(100);
-            return false;
+            await Task.Delay(300);
+            return name.ToLower() != "test";
         }
     }
 }

--- a/samples/Shared/SharedModels/Person.cs
+++ b/samples/Shared/SharedModels/Person.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using System.Threading.Tasks;
 
 namespace SharedModel
 {
@@ -13,12 +14,20 @@ namespace SharedModel
     {
         public PersonValidator()
         {
-            RuleFor(p => p.Name).NotEmpty().WithMessage("You must enter a name");
             RuleFor(p => p.Name).MaximumLength(50).WithMessage("Name cannot be longer than 50 characters");
             RuleFor(p => p.Age).NotEmpty().WithMessage("Age must be greater than 0");
             RuleFor(p => p.Age).LessThan(150).WithMessage("Age cannot be greater than 150");
             RuleFor(p => p.EmailAddress).NotEmpty().WithMessage("You must enter a email address");
             RuleFor(p => p.EmailAddress).EmailAddress().WithMessage("You must provide a valid email address");
+
+            RuleFor(x => x.Name).MustAsync(async (name, cancellationToken) => await IsUniqueAsync(name))
+                    .WithMessage("Name must be unique");
+        }
+
+        private async Task<bool> IsUniqueAsync(string name)
+        {
+            await Task.Delay(100);
+            return false;
         }
     }
 }

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using FluentValidation.Internal;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -9,12 +10,12 @@ namespace Blazored.FluentValidation
 {
     public static class EditContextFluentValidationExtensions
     {
-        public static EditContext AddFluentValidation(this EditContext editContext)
+        public static EditContext AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider)
         {
-            return AddFluentValidation(editContext, null);
+            return AddFluentValidation(editContext, serviceProvider, null);
         }
 
-        public static EditContext AddFluentValidation(this EditContext editContext, IValidator validator)
+        public static EditContext AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, IValidator validator)
         {
             if (editContext == null)
             {
@@ -24,19 +25,19 @@ namespace Blazored.FluentValidation
             var messages = new ValidationMessageStore(editContext);
 
             editContext.OnValidationRequested +=
-                (sender, eventArgs) => ValidateModel((EditContext)sender, messages, validator);
+                (sender, eventArgs) => ValidateModel((EditContext)sender, messages, serviceProvider, validator);
 
             editContext.OnFieldChanged +=
-                (sender, eventArgs) => ValidateField(editContext, messages, eventArgs.FieldIdentifier, validator);
+                (sender, eventArgs) => ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, validator);
 
             return editContext;
         }
 
-        private static async void ValidateModel(EditContext editContext, ValidationMessageStore messages, IValidator validator = null)
+        private static async void ValidateModel(EditContext editContext, ValidationMessageStore messages, IServiceProvider serviceProvider, IValidator validator = null)
         {
             if (validator == null)
             {
-                validator = GetValidatorForModel(editContext.Model);
+                validator = GetValidatorForModel(serviceProvider, editContext.Model);
             }
 
             var validationResults = await validator.ValidateAsync(editContext.Model);
@@ -50,14 +51,14 @@ namespace Blazored.FluentValidation
             editContext.NotifyValidationStateChanged();
         }
 
-        private static async void ValidateField(EditContext editContext, ValidationMessageStore messages, FieldIdentifier fieldIdentifier, IValidator validator = null)
+        private static async void ValidateField(EditContext editContext, ValidationMessageStore messages, FieldIdentifier fieldIdentifier, IServiceProvider serviceProvider, IValidator validator = null)
         {
             var properties = new[] { fieldIdentifier.FieldName };
             var context = new ValidationContext(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
 
             if (validator == null)
             {
-                validator = GetValidatorForModel(editContext.Model);
+                validator = GetValidatorForModel(serviceProvider, editContext.Model);
             }
 
             var validationResults = await validator.ValidateAsync(context);
@@ -68,7 +69,7 @@ namespace Blazored.FluentValidation
             editContext.NotifyValidationStateChanged();
         }
 
-        private static IValidator GetValidatorForModel(object model)
+        private static IValidator GetValidatorForModel(IServiceProvider serviceProvider, object model)
         {
             var abstractValidatorType = typeof(AbstractValidator<>).MakeGenericType(model.GetType());
 
@@ -89,9 +90,12 @@ namespace Blazored.FluentValidation
                 throw new TypeLoadException($"Unable to locate a validator of type {abstractValidatorType.FullName}");
             }
 
-            var modelValidatorInstance = (IValidator)Activator.CreateInstance(modelValidatorType);
+            if (serviceProvider == null)
+            {
+                return (IValidator)Activator.CreateInstance(modelValidatorType);
+            }
 
-            return modelValidatorInstance;
+            return (IValidator)ActivatorUtilities.CreateInstance(serviceProvider, modelValidatorType);
         }
     }
 }

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -32,14 +32,14 @@ namespace Blazored.FluentValidation
             return editContext;
         }
 
-        private static void ValidateModel(EditContext editContext, ValidationMessageStore messages, IValidator validator = null)
+        private static async void ValidateModel(EditContext editContext, ValidationMessageStore messages, IValidator validator = null)
         {
             if (validator == null)
             {
                 validator = GetValidatorForModel(editContext.Model);
             }
 
-            var validationResults = validator.Validate(editContext.Model);
+            var validationResults = await validator.ValidateAsync(editContext.Model);
 
             messages.Clear();
             foreach (var validationResult in validationResults.Errors)
@@ -50,7 +50,7 @@ namespace Blazored.FluentValidation
             editContext.NotifyValidationStateChanged();
         }
 
-        private static void ValidateField(EditContext editContext, ValidationMessageStore messages, in FieldIdentifier fieldIdentifier, IValidator validator = null)
+        private static async void ValidateField(EditContext editContext, ValidationMessageStore messages, FieldIdentifier fieldIdentifier, IValidator validator = null)
         {
             var properties = new[] { fieldIdentifier.FieldName };
             var context = new ValidationContext(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
@@ -60,7 +60,7 @@ namespace Blazored.FluentValidation
                 validator = GetValidatorForModel(editContext.Model);
             }
 
-            var validationResults = validator.Validate(context);
+            var validationResults = await validator.ValidateAsync(context);
 
             messages.Clear(fieldIdentifier);
             messages.AddRange(fieldIdentifier, validationResults.Errors.Select(error => error.ErrorMessage));

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -11,6 +11,8 @@ namespace Blazored.FluentValidation
 
         [Parameter] IValidator Validator { get; set; }
 
+        [Inject] IServiceProvider ServiceProvider { get; set; }
+
         protected override void OnInit()
         {
             if (CurrentEditContext == null)
@@ -21,7 +23,7 @@ namespace Blazored.FluentValidation
             }
 
             Console.WriteLine(Validator == null);
-            CurrentEditContext.AddFluentValidation(Validator);
+            CurrentEditContext.AddFluentValidation(ServiceProvider, Validator);
         }
     }
 }


### PR DESCRIPTION
Updated to use `ValidateAsync()` instead of `Validate()`
Added async rule to `PersonValidator` sample
Use `ActivatorUtilities.CreateInstance()` to allow dependency injection in validators