### PR TITLE
Add option to fully validate the whole model on every field change

### DIFF
--- a/samples/ServerSideBlazor/Pages/Index.razor
+++ b/samples/ServerSideBlazor/Pages/Index.razor
@@ -5,7 +5,7 @@
 <hr class="mb-5" />
 
 <EditForm Model="@Person" OnValidSubmit="@SubmitValidForm">
-    <FluentValidationValidator />
+    <FluentValidationValidator AlwaysValidateFullModel="true"/>
     <ValidationSummary />
 
     <p>

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -59,24 +59,6 @@ namespace Blazored.FluentValidation
             editContext.NotifyValidationStateChanged();
         }
 
-        private static async void ValidateModel1(EditContext editContext, ValidationMessageStore messages, IServiceProvider serviceProvider, IValidator validator = null)
-        {
-            if (validator == null)
-            {
-                validator = GetValidatorForModel(serviceProvider, editContext.Model);
-            }
-
-            var validationResults = await validator.ValidateAsync(editContext.Model);
-
-            messages.Clear();
-            foreach (var validationResult in validationResults.Errors)
-            {
-                messages.Add(editContext.Field(validationResult.PropertyName), validationResult.ErrorMessage);
-            }
-
-            editContext.NotifyValidationStateChanged();
-        }
-
         private static async void ValidateField(EditContext editContext, ValidationMessageStore messages, FieldIdentifier fieldIdentifier, IServiceProvider serviceProvider, IValidator validator = null)
         {
             var properties = new[] { fieldIdentifier.FieldName };

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -12,6 +12,12 @@ namespace Blazored.FluentValidation
         [CascadingParameter] EditContext CurrentEditContext { get; set; }
 
         [Parameter] public IValidator Validator { get; set; }
+        
+        /// <summary>
+        /// When set to true, a field change will cause the whole model will be re-validated.
+        /// When set to false, only the field that changed will be re-validated.
+        /// </summary>
+        [Parameter] public bool AlwaysValidateFullModel { get; set; }
 
 
         protected override void OnInitialized()
@@ -23,7 +29,7 @@ namespace Blazored.FluentValidation
                     $"inside an {nameof(EditForm)}.");
             }
 
-            CurrentEditContext.AddFluentValidation(ServiceProvider, Validator);
+            CurrentEditContext.AddFluentValidation(ServiceProvider, Validator, AlwaysValidateFullModel);
         }
     }
 }


### PR DESCRIPTION
Hi Chris

Here's my first stab at this, obviously feel free to reject if it's not what's required.

It does what we expected, but with the expected side-effect that as soon as the first field is validated all the other fields then show their validation failures, before the user has edited those fields, which isn't a great UX.  For my project I can live with that, it's preferable to the alternative of the fields not showing validation errors, but it's not the most elegant solution and I'll understand if you don't want it in your library.  That being said, people don't have to use it, and the default option is for it to be off, so I'm personally hoping you can live with it!

Steve Sanderson touched on that issue in [his example](https://blog.stevensanderson.com/2019/09/04/blazor-fluentvalidation/), quoting from that:

> - It doesn’t yet support validating individual fields. Instead, each time there’s an OnFieldChanged event, it revalidates the entire object. This is inefficient plus you can see validation messages for fields you haven’t yet edited.
>   - To fix this, we’d need some way to enumerate all the validatable properties reachable from the root object. Then inside the OnFieldChanged event, we’d take eventArgs.FieldIdentifier and translate that into a FluentValidation path chain string by checking which path string corresponds to the FieldIdentifier. Then we could tell FluentValidation only to validate that one property.
>   - Alternatively, FluentValidation could offer another overload to the Validate API that takes a callback that returns true/false for each field being considered to say whether or not it should be validated on this occasion.

I guess it would be possible to do something like the second approach within this library, by having a callback method that takes a field name and returns a list of related field's names that the library could then also call validate for.  However, I have the feeling that may be easier said than done once child collections are introduced into the mix, and I'm not sure it's really the responsibility of this library.  I'm having difficulty working out where that really belongs!

