### PR TITLE
Update field level validation

### DIFF
--- a/Blazored.FluentValidation.sln
+++ b/Blazored.FluentValidation.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazored.FluentValidation.Tests", "tests\Blazored.FluentValidation.Tests\Blazored.FluentValidation.Tests.csproj", "{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +79,18 @@ Global
 		{5C5D43B9-899C-44BD-8405-E81CCDB6F0A8}.Release|x64.Build.0 = Release|Any CPU
 		{5C5D43B9-899C-44BD-8405-E81CCDB6F0A8}.Release|x86.ActiveCfg = Release|Any CPU
 		{5C5D43B9-899C-44BD-8405-E81CCDB6F0A8}.Release|x86.Build.0 = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Debug|x86.Build.0 = Debug|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|x64.Build.0 = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{59F003D9-C4B8-4740-A6AF-9C05BB637DF2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/ClientSideBlazor/Startup.cs
+++ b/samples/ClientSideBlazor/Startup.cs
@@ -1,5 +1,7 @@
+using FluentValidation;
 using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using SharedModel;
 
 namespace ClientSideBlazor
 {
@@ -7,6 +9,7 @@ namespace ClientSideBlazor
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddTransient<IValidator<Person>, PersonValidator>();
         }
 
         public void Configure(IComponentsApplicationBuilder app)

--- a/samples/ServerSideBlazor/ServerSideBlazor.csproj
+++ b/samples/ServerSideBlazor/ServerSideBlazor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.5.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ServerSideBlazor/Startup.cs
+++ b/samples/ServerSideBlazor/Startup.cs
@@ -1,8 +1,10 @@
+using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using SharedModel;
 
 namespace ServerSideBlazor
 {
@@ -19,7 +21,8 @@ namespace ServerSideBlazor
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddRazorPages();
+            services.AddRazorPages()
+                .AddFluentValidation(options => options.RegisterValidatorsFromAssemblyContaining<Person>());
             services.AddServerSideBlazor();
         }
 

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -23,7 +23,7 @@ namespace Blazored.FluentValidation
                     $"inside an {nameof(EditForm)}.");
             }
 
-            CurrentEditContext.AddFluentValidation(ServiceProvider, Validator);
+            CurrentEditContext.AddFluentValidation(new ServiceProviderValidatorFactory(ServiceProvider), Validator);
         }
     }
 }

--- a/src/Blazored.FluentValidation/GenericTypeExtensions.cs
+++ b/src/Blazored.FluentValidation/GenericTypeExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+
+namespace Blazored.FluentValidation
+{
+    internal static class GenericTypeExtensions
+    {
+        public static string GetGenericTypeName(this Type type)
+        {
+            string typeName;
+
+            if (type.IsGenericType)
+            {
+                var genericTypes = string.Join(",", type.GetGenericArguments().Select(t => t.Name).ToArray());
+                typeName = $"{type.Name.Remove(type.Name.IndexOf('`'))}<{genericTypes}>";
+            }
+            else
+            {
+                typeName = type.Name;
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/src/Blazored.FluentValidation/ServiceProviderValidatorFactory.cs
+++ b/src/Blazored.FluentValidation/ServiceProviderValidatorFactory.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using FluentValidation;
+
+namespace Blazored.FluentValidation
+{
+    public class ServiceProviderValidatorFactory : ValidatorFactoryBase
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceProviderValidatorFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public override IValidator CreateInstance(Type validatorType)
+        {
+            return _serviceProvider.GetService(validatorType) as IValidator;
+        }
+    }
+}

--- a/tests/Blazored.FluentValidation.Tests/Blazored.FluentValidation.Tests.csproj
+++ b/tests/Blazored.FluentValidation.Tests/Blazored.FluentValidation.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Blazored.FluentValidation\Blazored.FluentValidation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Blazored.FluentValidation.Tests/EditContextFluentValidationsExtensionsTest.cs
+++ b/tests/Blazored.FluentValidation.Tests/EditContextFluentValidationsExtensionsTest.cs
@@ -1,0 +1,269 @@
+using System;
+using FluentValidation;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Blazored.FluentValidation.Tests
+{
+    public class EditContextFluentValidationsExtensionsTest
+    {
+        internal class TopLevelModelValidator : AbstractValidator<TopLevelModel>
+        {
+            public TopLevelModelValidator()
+            {
+                RuleFor(p => p.Name).NotEmpty().Length(3, 50);
+                RuleFor(p => p.TestModel)
+                    .SetValidator(new TestModelValidator());
+            }
+        }
+
+        internal class TestModelValidator : AbstractValidator<TestModel>
+        {
+            public TestModelValidator()
+            {
+                RuleFor(p => p.RequiredString).NotEmpty().WithMessage("RequiredString:required");
+                RuleFor(p => p.IntFrom1To100).InclusiveBetween(1, 100).WithMessage("IntFrom1To100:range");
+            }
+        }
+
+        internal class TopLevelModel
+        {
+            public string Name { get; set; }
+            public TestModel TestModel { get; set; }
+        }
+
+        internal class TestModel
+        {
+            public string RequiredString { get; set; }
+            public int IntFrom1To100 { get; set; }
+#pragma warning disable 649
+            public string ThisWillNotBeValidatedBecauseItIsAField;
+            private string ThisWillNotBeValidatedBecauseItIsPrivate { get; set; }
+            internal string ThisWillNotBeValidatedBecauseItIsInternal { get; set; }
+#pragma warning restore 649
+        }
+
+        [Theory]
+        [InlineData(nameof(TestModel.ThisWillNotBeValidatedBecauseItIsAField))]
+        [InlineData(nameof(TestModel.ThisWillNotBeValidatedBecauseItIsInternal))]
+        [InlineData("ThisWillNotBeValidatedBecauseItIsPrivate")]
+        [InlineData("This does not correspond to anything")]
+        [InlineData("")]
+        public void IgnoresFieldChangesThatDoNotCorrespondToAValidatableProperty(string fieldName)
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TestModel>, TestModelValidator>()
+                .BuildServiceProvider();
+            var editContext =
+                new EditContext(new TestModel()).AddFluentValidation(
+                    new ServiceProviderValidatorFactory(serviceProvider));
+            var onValidationStateChangedCount = 0;
+            editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
+
+            // act && assert: Ignores field changes that don't correspond to a validatable property
+            editContext.NotifyFieldChanged(editContext.Field(fieldName));
+            onValidationStateChangedCount.ShouldBe(0);
+
+            // act && assert: For sanity, observe that we would have validated if it was a validatable property
+            editContext.NotifyFieldChanged(editContext.Field(nameof(TestModel.RequiredString)));
+            onValidationStateChangedCount.ShouldBe(1);
+        }
+
+        [Fact]
+        public void CannotUseNullEditContext()
+        {
+            // arrange
+            var editContext = (EditContext) null;
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidatorFactory, ServiceProviderValidatorFactory>().BuildServiceProvider();
+
+            // act && assert
+            var ex = Should.Throw<ArgumentNullException>(() =>
+                editContext.AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider)));
+            ex.ParamName.ShouldBe("editContext");
+        }
+
+        [Fact]
+        public void CannotUseNullValidatorFactory()
+        {
+            // arrange
+            var editContext = new EditContext(new object());
+
+            // act && assert
+            var ex = Should.Throw<ArgumentNullException>(() => editContext.AddFluentValidation(null));
+            ex.ParamName.ShouldBe("validatorFactory");
+        }
+
+        [Fact]
+        public void ClearsExistingValidationMessagesOnFurtherRuns()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TestModel>, TestModelValidator>()
+                .BuildServiceProvider();
+
+            var model = new TestModel {IntFrom1To100 = 101};
+            var editContext =
+                new EditContext(model).AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider));
+
+            // act && assert: initially invalid
+            editContext.Validate().ShouldBeFalse();
+
+            // act && assert: becomes valid
+            model.RequiredString = "Hello";
+            model.IntFrom1To100 = 100;
+
+            editContext.Validate().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GetsValidationMessageFromFluentValidation()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TestModel>, TestModelValidator>()
+                .BuildServiceProvider();
+
+            var model = new TestModel {IntFrom1To100 = 101};
+            var editContext =
+                new EditContext(model).AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider));
+
+            // act
+            var isValid = editContext.Validate();
+
+            // assert
+            isValid.ShouldBeFalse();
+
+            new[]
+            {
+                "RequiredString:required",
+                "IntFrom1To100:range"
+            }.ShouldBe(editContext.GetValidationMessages());
+
+            new[]
+            {
+                "RequiredString:required"
+            }.ShouldBe(editContext.GetValidationMessages(editContext.Field(nameof(TestModel.RequiredString))));
+
+            new[]
+            {
+                "IntFrom1To100:range"
+            }.ShouldBe(editContext.GetValidationMessages(editContext.Field(nameof(TestModel.IntFrom1To100))));
+        }
+
+        [Fact]
+        public void NotifiesValidationStateChangedAfterObjectValidation()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TestModel>, TestModelValidator>()
+                .BuildServiceProvider();
+
+            var model = new TestModel {IntFrom1To100 = 101};
+            var editContext =
+                new EditContext(model).AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider));
+            var onValidationStateChangedCount = 0;
+            editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
+
+            // act && assert: notifies after invalid results
+            editContext.Validate().ShouldBeFalse();
+            onValidationStateChangedCount.ShouldBe(1);
+
+            // act && assert: notifies after valid results
+            model.RequiredString = "Hello";
+            model.IntFrom1To100 = 100;
+            editContext.Validate().ShouldBeTrue();
+            onValidationStateChangedCount.ShouldBe(2);
+
+            // act && assert: notifies even if results haven't changed
+            editContext.Validate().ShouldBeTrue();
+            onValidationStateChangedCount.ShouldBe(3);
+        }
+
+        [Fact]
+        public void PerformsPerPropertyValidationOnFieldChange()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TestModel>, TestModelValidator>()
+                .AddTransient<IValidator<TopLevelModel>, TopLevelModelValidator>()
+                .BuildServiceProvider();
+
+            var independentTopLevelModel = new TopLevelModel();
+            var model = new TestModel {IntFrom1To100 = 101};
+            var editContext =
+                new EditContext(independentTopLevelModel).AddFluentValidation(
+                    new ServiceProviderValidatorFactory(serviceProvider));
+            var onValidationStateChangedCount = 0;
+            var requiredStringIdentifier = new FieldIdentifier(model, nameof(TestModel.RequiredString));
+            var intFrom1To100Identifier = new FieldIdentifier(model, nameof(TestModel.IntFrom1To100));
+            editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
+
+            // act && assert: notify about RequiredString
+            editContext.NotifyFieldChanged(requiredStringIdentifier);
+            onValidationStateChangedCount.ShouldBe(1);
+            new[] {"RequiredString:required"}.ShouldBe(editContext.GetValidationMessages());
+
+            // act && assert: fix RequiredString, but only notify about IntFrom1To100
+            model.RequiredString = "Hello";
+            editContext.NotifyFieldChanged(intFrom1To100Identifier);
+            onValidationStateChangedCount.ShouldBe(2);
+            new[]
+            {
+                "RequiredString:required",
+                "IntFrom1To100:range"
+            }.ShouldBe(editContext.GetValidationMessages());
+
+            // act && assert
+            editContext.NotifyFieldChanged(requiredStringIdentifier);
+            onValidationStateChangedCount.ShouldBe(3);
+            new[] {"IntFrom1To100:range"}.ShouldBe(editContext.GetValidationMessages());
+        }
+
+        [Fact]
+        public void ReturnsEditContextForChaining()
+        {
+            // arrange
+            var editContext = new EditContext(new object());
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            // act
+            var returnValue = editContext.AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider));
+
+            // assert
+            editContext.ShouldBeSameAs(returnValue);
+        }
+
+        [Fact]
+        public void ShouldNotValidateNestedModelsIfRuleDoesNotExist()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection()
+                .AddTransient<IValidator<TopLevelModel>, TopLevelModelValidator>()
+                .BuildServiceProvider();
+
+            var model = new TopLevelModel
+            {
+                Name = "ab",
+                TestModel = new TestModel()
+            };
+            var editContext =
+                new EditContext(model).AddFluentValidation(new ServiceProviderValidatorFactory(serviceProvider));
+            var onValidationStateChangedCount = 0;
+            var requiredNameIdentifier = new FieldIdentifier(model, nameof(TopLevelModel.Name));
+            var requiredStringIdentifier = new FieldIdentifier(model, nameof(TestModel.RequiredString));
+            editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
+
+            // act && assert
+            editContext.NotifyFieldChanged(requiredStringIdentifier);
+            onValidationStateChangedCount.ShouldBe(0);
+
+            // act && assert
+            editContext.NotifyFieldChanged(requiredNameIdentifier);
+            onValidationStateChangedCount.ShouldBe(1);
+        }
+    }
+}


### PR DESCRIPTION
Ok, this PR was a bit bigger than i intended but here are the changes.

- Added unit tests - This allowed me to step through and debug the code.
- Replaced GetValidatorForModel with a factory. It means manually registering with the DI in Client Blazor, but its probably better to be explicit about registrations. Something like scrutor could always be used to register all the validators, but i think it would be better to leave this up to the developer.
- Updated the logic when validating fields. It now checks if a validator is available for a given field, if not then it just skips the validation for that field.

```
            if (validator != null)
            {
                var descriptor = validator.CreateDescriptor(); 
                var fieldValidators = descriptor.GetValidatorsForMember(fieldIdentifier.FieldName);
                if (!fieldValidators.Any())
                {
                    return;
                }

                var properties = new[] { fieldIdentifier.FieldName };
                var context = new ValidationContext(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));

                var validationResults = await validator.ValidateAsync(context);

                messages.Clear(fieldIdentifier);
                messages.Add(fieldIdentifier, validationResults.Errors.Select(error => error.ErrorMessage));

                editContext.NotifyValidationStateChanged();
            }
```

Should fix #16 