### PR TITLE
Enable interception of edit context model type when attempting to retrieve validator instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,27 @@ You can control this behaviour using the `DisableAssemblyScanning` parameter. If
 You can find examples of different configurations in the sample projects. The Blazor Server project is configured to load validators from DI only. The Blazor WebAssembly project is setup to load validators using reflection.
 
 **Note:** When scanning assemblies the component will swallow any exceptions thrown by that process. This is to stop exceptions thrown by scanning third party dependencies crashing your app.
+
+## Intercepting the Model Type Used to Find Validators
+By default, the component will use the type of the model being validated to determine what validator to resolve from the DI container.  In most scenarios, this will be the model's compile-time type; however, if your model is being proxied (by [Castle Project's `DynamicProxy`](http://www.castleproject.org/projects/dynamicproxy/), say), the component will fail to resolve validators from the DI container or from scanning assemblies because the runtime type differs from the compile-time type used to implement the validator.
+
+You can control this behaviour using the `ModelTypeFunc` parameter.
+```csharp
+// using System;
+// using Castle.DynamicProxy;
+
+public static class ModelTypeInterceptor
+{
+	public static Type Execute(object model)
+	{
+		if (model is IProxyTargetAccessor proxy)
+			return proxy.DynProxyGetTarget().GetType();
+
+		return model.GetType();
+	}
+}
+```
+
+```html
+<FluentValidationValidator ModelTypeFunc='@ModelTypeInterceptor.Execute' />
+```

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -94,8 +94,8 @@ namespace Blazored.FluentValidation
 
         private static IValidator GetValidatorForModel(IServiceProvider serviceProvider, object model, bool disableAssemblyScanning, MakeTypeUsingEditContextModelDelegate modelTypeFunc)
         {
-	        var modelType = modelTypeFunc.Invoke(model.GetType());
-	        var validatorType = typeof(IValidator<>).MakeGenericType(modelType);
+            var modelType = modelTypeFunc.Invoke(model.GetType());
+            var validatorType = typeof(IValidator<>).MakeGenericType(modelType);
             if (serviceProvider != null)
             {
                 try

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -8,7 +8,7 @@ namespace Blazored.FluentValidation
 {
     public class FluentValidationValidator : ComponentBase
     {
-	    internal static readonly MakeTypeUsingEditContextModelDelegate ModelTypePassthrough = model => model.GetType();
+        internal static readonly MakeTypeUsingEditContextModelDelegate ModelTypePassthrough = model => model.GetType();
 
         [Inject] private IServiceProvider ServiceProvider { get; set; }
 

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -8,12 +8,15 @@ namespace Blazored.FluentValidation
 {
     public class FluentValidationValidator : ComponentBase
     {
+	    internal static readonly MakeTypeUsingEditContextModelDelegate ModelTypePassthrough = model => model.GetType();
+
         [Inject] private IServiceProvider ServiceProvider { get; set; }
 
         [CascadingParameter] private EditContext CurrentEditContext { get; set; }
 
         [Parameter] public IValidator Validator { get; set; }
         [Parameter] public bool DisableAssemblyScanning { get; set; }
+        [Parameter] public MakeTypeUsingEditContextModelDelegate ModelTypeFunc { get; set; }
 
         internal Action<ValidationStrategy<object>> Options;
 
@@ -40,7 +43,7 @@ namespace Blazored.FluentValidation
                     $"inside an {nameof(EditForm)}.");
             }
 
-            CurrentEditContext.AddFluentValidation(ServiceProvider, DisableAssemblyScanning, Validator, this);
+            CurrentEditContext.AddFluentValidation(ServiceProvider, DisableAssemblyScanning, Validator, this, ModelTypeFunc ?? ModelTypePassthrough);
         }
     }
 }

--- a/src/Blazored.FluentValidation/MakeTypeUsingEditContextModelDelegate.cs
+++ b/src/Blazored.FluentValidation/MakeTypeUsingEditContextModelDelegate.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazored.FluentValidation
+{
+	public delegate Type MakeTypeUsingEditContextModelDelegate(object model);
+}


### PR DESCRIPTION
#72 has information about the usage scenario: retrieving a validator instance for a model type that has been proxied.

- adds `MakeTypeUsingEditContextModelDelegate` (`object => Type`)
- `FluentValidationValidator` has new optional `ModelTypeFunc` parameter; if no value specified, then the `model => model.GetType()` delegate is used
- added overload of `EditContextFluentValidationExtensions.AddFluentValidation` accepting `MakeTypeUsingEditContextModelDelegate`