### PR TITLE
Passing parent model instead of nested type to resolve exception thrown by FluentValidation

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -68,9 +68,9 @@ namespace Blazored.FluentValidation
                                                 IValidator validator = null)
         {
             var properties = new[] { fieldIdentifier.FieldName };
-            var context = new ValidationContext<object>(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
+            var context = new ValidationContext<object>(editContext.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
 
-            validator ??= GetValidatorForModel(serviceProvider, fieldIdentifier.Model, disableAssemblyScanning);
+            validator ??= GetValidatorForModel(serviceProvider, editContext.Model, disableAssemblyScanning);
 
             if (validator is object)
             {


### PR DESCRIPTION
Passing parent model instead of nested type to resolve exception thrown by FluentValidation
Thanks to @AmirMahdiNassiri for pointing to the line in the source code with the issue.
Fixes issue #76