### PR TITLE
Change ToString() to new string() in ToFieldIdentifier method.

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using FluentValidation.Internal;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
@@ -143,7 +143,7 @@ namespace Blazored.FluentValidation
 
             var obj = editContext.Model;
             var nextTokenEnd = propertyPath.IndexOfAny(Separators);
-            
+
             // Optimize for a scenario when parsing isn't needed.
             if (nextTokenEnd < 0)
             {
@@ -169,7 +169,7 @@ namespace Blazored.FluentValidation
                     {
                         // we've got an Item property
                         var indexerType = prop.GetIndexParameters()[0].ParameterType;
-                        var indexerValue = Convert.ChangeType(nextToken.ToString(), indexerType);
+                        var indexerValue = Convert.ChangeType(new string(nextToken), indexerType);
                         newObj = prop.GetValue(obj, new object[] { indexerValue });
                     }
                     else
@@ -190,10 +190,10 @@ namespace Blazored.FluentValidation
                 else
                 {
                     // It's a regular property
-                    var prop = obj.GetType().GetProperty(nextToken.ToString());
+                    var prop = obj.GetType().GetProperty(new string(nextToken));
                     if (prop == null)
                     {
-                        throw new InvalidOperationException($"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
+                        throw new InvalidOperationException($"Could not find property named {new string(nextToken)} on object of type {obj.GetType().FullName}.");
                     }
                     newObj = prop.GetValue(obj);
                 }
@@ -201,15 +201,15 @@ namespace Blazored.FluentValidation
                 if (newObj == null)
                 {
                     // This is as far as we can go
-                    return new FieldIdentifier(obj, nextToken.ToString());
+                    return new FieldIdentifier(obj, new string(nextToken));
                 }
 
                 obj = newObj;
-                
+
                 nextTokenEnd = propertyPathAsSpan.IndexOfAny(Separators);
                 if (nextTokenEnd < 0)
                 {
-                    return new FieldIdentifier(obj, propertyPathAsSpan.ToString());
+                    return new FieldIdentifier(obj, new string(propertyPathAsSpan));
                 }
             }
         }


### PR DESCRIPTION
Changind the ToString to new string() makes the ToFieldIdentifier() method about 3% faster.

|               Method |         PropertyPath |      Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|--------------------- |--------------------- |----------:|---------:|---------:|------:|-------:|----------:|
|    ToFieldIdentifier | Address.Keys[0].Name | 446.88 ns | 1.735 ns | 1.623 ns |  1.00 | 0.0257 |     216 B |
| ToFieldIdentifierNew | Address.Keys[0].Name | 433.24 ns | 1.308 ns | 1.224 ns |  0.97 | 0.0257 |     216 B |
|                      |                      |           |          |          |       |        |           |
|    ToFieldIdentifier |     Address.Postcode | 142.37 ns | 0.215 ns | 0.191 ns |  1.00 | 0.0095 |      80 B |
| ToFieldIdentifierNew |     Address.Postcode | 142.63 ns | 0.202 ns | 0.189 ns |  1.00 | 0.0095 |      80 B |
|                      |                      |           |          |          |       |        |           |
|    ToFieldIdentifier |            FirstName |  32.87 ns | 0.041 ns | 0.038 ns |  1.00 |      - |         - |
| ToFieldIdentifierNew |            FirstName |  31.14 ns | 0.049 ns | 0.041 ns |  0.95 |      - |         - |