### PR TITLE
small async fix - awaiting validation handlers

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -15,26 +15,23 @@ namespace Blazored.FluentValidation
         private static readonly List<string> ScannedAssembly = new List<string>();
         private static readonly List<AssemblyScanResult> AssemblyScanResults = new List<AssemblyScanResult>();
 
-        public static EditContext AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator validator, FluentValidationValidator fluentValidationValidator)
+        public static async Task<EditContext> AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator validator, FluentValidationValidator fluentValidationValidator)
 
         {
-            if (editContext == null)
-            {
-                throw new ArgumentNullException(nameof(editContext));
-            }
+            ArgumentNullException.ThrowIfNull(editContext, nameof(editContext));
 
             var messages = new ValidationMessageStore(editContext);
 
             editContext.OnValidationRequested +=
-                (sender, eventArgs) => ValidateModel((EditContext)sender, messages, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
+                async (sender, eventArgs) => await ValidateModel((EditContext)sender, messages, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
 
             editContext.OnFieldChanged +=
-                (sender, eventArgs) => ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
+               async (sender, eventArgs) => await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
 
-            return editContext;
+            return await Task.FromResult(editContext);
         }
 
-        private static async void ValidateModel(EditContext editContext,
+        private static async Task ValidateModel(EditContext editContext,
                                                 ValidationMessageStore messages,
                                                 IServiceProvider serviceProvider,
                                                 bool disableAssemblyScanning,
@@ -60,7 +57,7 @@ namespace Blazored.FluentValidation
             }
         }
 
-        private static async void ValidateField(EditContext editContext,
+        private static async Task ValidateField(EditContext editContext,
                                                 ValidationMessageStore messages,
                                                 FieldIdentifier fieldIdentifier,
                                                 IServiceProvider serviceProvider,

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -31,7 +31,7 @@ namespace Blazored.FluentValidation
             }
         }
 
-        protected override void OnInitialized()
+        protected override async Task OnInitializedAsync()
         {
             if (CurrentEditContext == null)
             {
@@ -40,7 +40,8 @@ namespace Blazored.FluentValidation
                     $"inside an {nameof(EditForm)}.");
             }
 
-            CurrentEditContext.AddFluentValidation(ServiceProvider, DisableAssemblyScanning, Validator, this);
+            await CurrentEditContext.AddFluentValidation(ServiceProvider, DisableAssemblyScanning, Validator, this);
+            await base.OnInitializedAsync();
         }
     }
 }


### PR DESCRIPTION
Loving the Blazored.FluentValidation component! Now starting to use it for my smaller hobby projects 😄 

A super small tweak to correct async / await on the validation handler methods to allow them to resolve their tasks better in the event that there's an exception or issue, which will allow that exception to be placed on the Task object, allowing any exceptions to be brought back to the caller. 

From spotting at the time the methods returned async void which would make it a little bit awkward to handle any exceptions thrown out, with it being **async void** it'll raise the exception onto the **SynchronizationContext** that was active when the method began.

Would be useful in the case of testing with **BUnit** where the form or thing that's being validated is a bit reactive with **InvokeAsync(() => StateHasChanged());**
