### PR TITLE
Change FluentValidation version

### DIFF
--- a/src/Blazored.FluentValidation/Blazored.FluentValidation.csproj
+++ b/src/Blazored.FluentValidation/Blazored.FluentValidation.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation" Version="11.0.0" />
+		<PackageReference Include="FluentValidation" Version="11.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Blazored/FluentValidation currently pins down the version of FluentValidation to specific patch version. This prevents usage of the newer versions of FluentValidation, which might contain necessary bugfixes.

If this is deemed too risky, we can also pin down the minor version by `Version="11.0.*`.