### PR TITLE
Option to provide `RootContextData`

### DIFF
--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -5,7 +5,7 @@
 <hr class="mb-5" />
 
 <EditForm Model="@_person" OnValidSubmit="@SubmitValidForm">
-    <FluentValidationValidator @ref="_fluentValidationValidator" DisableAssemblyScanning="@true" />
+    <FluentValidationValidator @ref="_fluentValidationValidator" DisableAssemblyScanning="@true" ContextData="_data" />
     <ValidationSummary />
 
     <p>
@@ -72,6 +72,10 @@
 @code {
     private readonly Person _person = new();
     private FluentValidationValidator? _fluentValidationValidator;
+    private readonly IDictionary<string, object> _data = new Dictionary<string, object>
+    {
+        { "MinAgeLimit", 18 }
+    };
 
     private void SubmitValidForm() 
         => Console.WriteLine("Form Submitted Successfully!");

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -5,7 +5,7 @@
 <hr class="mb-5" />
 
 <EditForm Model="@_person" OnSubmit="@SubmitFormAsync">
-    <FluentValidationValidator @ref="_fluentValidationValidator" Options="@(options => options.IncludeAllRuleSets())" />
+    <FluentValidationValidator @ref="_fluentValidationValidator" Options="@(options => options.IncludeAllRuleSets())" ContextData="_data" />
     <ValidationSummary />
 
     <p>
@@ -72,6 +72,10 @@
 @code {
     private readonly Person _person = new();
     private FluentValidationValidator? _fluentValidationValidator;
+    private readonly IDictionary<string, object> _data = new Dictionary<string, object>
+    {
+        { "MinAgeLimit", 18 }
+    };
 
     private async Task SubmitFormAsync()
     {

--- a/samples/Shared/SharedModels/Person.cs
+++ b/samples/Shared/SharedModels/Person.cs
@@ -28,6 +28,13 @@ namespace SharedModels
 
             RuleFor(p => p.Age)
                 .NotNull().WithMessage("You must enter your age")
+                .Custom((age, context) =>
+                {
+                    if (context.RootContextData.TryGetValue("MinAgeLimit", out var ageValue) && ageValue is int minAge && age < minAge)
+                    {
+                        context.AddFailure($"Age must be greater than {minAge}");
+                    }
+                })
                 .GreaterThanOrEqualTo(0).WithMessage("Age must be greater than 0")
                 .LessThan(150).WithMessage("Age cannot be greater than 150");
 

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -23,7 +23,7 @@ public static class EditContextFluentValidationExtensions
             async (sender, _) => await ValidateModel((EditContext)sender!, messages, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
 
         editContext.OnFieldChanged +=
-            async (_, eventArgs) => await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
+            async (_, eventArgs) => await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
     }
 
     private static async Task ValidateModel(EditContext editContext,
@@ -52,6 +52,8 @@ public static class EditContextFluentValidationExtensions
                 context = new ValidationContext<object>(editContext.Model);
             }
 
+            FillRootContextData(context, fluentValidationValidator.ContextData);
+
             var asyncValidationTask = validator.ValidateAsync(context);
             editContext.Properties[PendingAsyncValidation] = asyncValidationTask;
             var validationResults = await asyncValidationTask;
@@ -72,11 +74,14 @@ public static class EditContextFluentValidationExtensions
         FieldIdentifier fieldIdentifier,
         IServiceProvider serviceProvider,
         bool disableAssemblyScanning,
+        FluentValidationValidator fluentValidationValidator,
         IValidator? validator = null)
     {
         var properties = new[] { fieldIdentifier.FieldName };
         var context = new ValidationContext<object>(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
-            
+
+        FillRootContextData(context, fluentValidationValidator.ContextData);
+
         validator ??= GetValidatorForModel(serviceProvider, fieldIdentifier.Model, disableAssemblyScanning);
 
         if (validator is not null)
@@ -216,6 +221,17 @@ public static class EditContextFluentValidationExtensions
             if (nextTokenEnd < 0)
             {
                 return new FieldIdentifier(obj, propertyPathAsSpan.ToString());
+            }
+        }
+    }
+
+    private static void FillRootContextData(ValidationContext<object> context, IDictionary<string, object>? data)
+    {
+        if (data is not null)
+        {
+            foreach (var item in data)
+            {
+                context.RootContextData[item.Key] = item.Value;
             }
         }
     }

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -16,6 +16,7 @@ public class FluentValidationValidator : ComponentBase
     [Parameter] public IValidator? Validator { get; set; }
     [Parameter] public bool DisableAssemblyScanning { get; set; }
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
+    [Parameter] public IDictionary<string, object>? ContextData { get; set; }
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
 
     public bool Validate(Action<ValidationStrategy<object>>? options = null)


### PR DESCRIPTION
`FluentValidation` allows developer to provide [additional data](https://docs.fluentvalidation.net/en/latest/advanced.html#root-context-data) for validation which can be utilized when defining validation rules. Unfortunately `FluentValidationValidator` component does not provide such an option to do so (parameter binding).

This PR adds a new property/parameter `ContextData` which can be used to bind `Dictionary` with additional data which will be provided to the validation pipeline.

Examples were modified accordingly to showcase the new option.