### PR TITLE
Validate MemberToCompare and original

### DIFF
--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -63,6 +63,18 @@
         <ValidationMessage For="@(() => _person.Address.Postcode)" />
     </p>
 
+    <p>
+        <label>Start Lucky Number Range: </label>
+        <InputNumber @bind-Value="@_person.StartLuckyNumberRange" />
+        <ValidationMessage For="@(() => _person.StartLuckyNumberRange)" />
+    </p>
+
+    <p>
+        <label>End Lucky Number Range: </label>
+        <InputNumber @bind-Value="@_person.EndLuckyNumberRange" />
+        <ValidationMessage For="@(() => _person.EndLuckyNumberRange)" />
+    </p>
+
     <button type="submit">Save</button>
 
 </EditForm>
@@ -73,9 +85,9 @@
     private readonly Person _person = new();
     private FluentValidationValidator? _fluentValidationValidator;
 
-    private void SubmitValidForm() 
+    private void SubmitValidForm()
         => Console.WriteLine("Form Submitted Successfully!");
 
-    private void PartialValidate() 
+    private void PartialValidate()
         => Console.WriteLine($"Partial validation result : {_fluentValidationValidator?.Validate(options => options.IncludeRuleSets("Names"))}");
 }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -63,6 +63,18 @@
         <ValidationMessage For="@(() => _person.Address.Postcode)" />
     </p>
 
+    <p>
+        <label>Start Lucky Number Range: </label>
+        <InputNumber @bind-Value="@_person.StartLuckyNumberRange" />
+        <ValidationMessage For="@(() => _person.StartLuckyNumberRange)" />
+    </p>
+
+    <p>
+        <label>End Lucky Number Range: </label>
+        <InputNumber @bind-Value="@_person.EndLuckyNumberRange" />
+        <ValidationMessage For="@(() => _person.EndLuckyNumberRange)" />
+    </p>
+
     <button type="submit">Save</button>
 
 </EditForm>

--- a/samples/Shared/SharedModels/Person.cs
+++ b/samples/Shared/SharedModels/Person.cs
@@ -9,6 +9,8 @@ namespace SharedModels
         public int? Age { get; set; }
         public string? EmailAddress { get; set; }
         public Address Address { get; set; } = new();
+        public int StartLuckyNumberRange { get; set; }
+        public int EndLuckyNumberRange { get; set; }
     }
 
     public class PersonValidator : AbstractValidator<Person>
@@ -35,6 +37,9 @@ namespace SharedModels
                 .NotEmpty().WithMessage("You must enter an email address")
                 .EmailAddress().WithMessage("You must provide a valid email address")
                 .MustAsync(async (email, _) => await IsUniqueAsync(email)).WithMessage("Email address must be unique");
+
+            RuleFor(p => p.StartLuckyNumberRange).LessThan(p => p.EndLuckyNumberRange).WithMessage("Start lucky number must be less than end lucky number");
+            RuleFor(p => p.EndLuckyNumberRange).GreaterThan(p => p.StartLuckyNumberRange).WithMessage("End lucky number must be greater than start lucky number");
 
             RuleFor(p => p.Address).SetValidator(new AddressValidator());
         }


### PR DESCRIPTION
When using comparison (like GreaterThan or LessThan), currently only the validator fires for the item you're entering data for; not the one being compared to.  The message stays on the "other item" until you visit and change the value for that field.

This branch validates both the field with data being entered, as well as the field its being compared to.  So if validation fails, both fields light up.  If validation succeeds, both fields stop lighting up.