### PR TITLE
Moved event handler logic to its own class which can be disposed of properly.

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -2,6 +2,8 @@
 using FluentValidation.Internal;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel.DataAnnotations;
+using System.Net.NetworkInformation;
 using static FluentValidation.AssemblyScanner;
 
 namespace Blazored.FluentValidation;
@@ -13,210 +15,237 @@ public static class EditContextFluentValidationExtensions
     private static readonly List<AssemblyScanResult> AssemblyScanResults = new();
     public const string PendingAsyncValidation = "AsyncValidationTask";
 
-    public static void AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator? validator, FluentValidationValidator fluentValidationValidator)
+    public static IDisposable AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator? validator, FluentValidationValidator fluentValidationValidator)
     {
         ArgumentNullException.ThrowIfNull(editContext, nameof(editContext));
 
-        var messages = new ValidationMessageStore(editContext);
-
-        editContext.OnValidationRequested +=
-            async (sender, _) => await ValidateModel((EditContext)sender!, messages, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
-
-        editContext.OnFieldChanged +=
-            async (_, eventArgs) => await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
+        return new FluentValidationEventSubscriptions(editContext, serviceProvider, disableAssemblyScanning, validator, fluentValidationValidator);
     }
 
-    private static async Task ValidateModel(EditContext editContext,
-        ValidationMessageStore messages,
-        IServiceProvider serviceProvider,
-        bool disableAssemblyScanning,
-        FluentValidationValidator fluentValidationValidator,
-        IValidator? validator = null)
+
+
+    private sealed class FluentValidationEventSubscriptions : IDisposable
     {
-        validator ??= GetValidatorForModel(serviceProvider, editContext.Model, disableAssemblyScanning);
+        private readonly EditContext _editContext;
+        private readonly IServiceProvider? _serviceProvider;
+        private readonly ValidationMessageStore _messages;
+        private readonly bool _disableAssemblyScanning;
+        private readonly FluentValidationValidator _fluentValidationValidator;
+        private IValidator? _validator;
 
-        if (validator is not null)
+        public FluentValidationEventSubscriptions(EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator? validator, FluentValidationValidator fluentValidationValidator)
         {
-            ValidationContext<object> context;
+            _editContext = editContext ?? throw new ArgumentNullException(nameof(editContext));
+            _serviceProvider = serviceProvider;
+            _messages = new ValidationMessageStore(_editContext);
+            _disableAssemblyScanning = disableAssemblyScanning;
+            _validator = validator;
+            _fluentValidationValidator = fluentValidationValidator;
 
-            if (fluentValidationValidator.ValidateOptions is not null)
-            {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.ValidateOptions);
-            }
-            else if (fluentValidationValidator.Options is not null)
-            {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.Options);
-            }
-            else
-            {
-                context = new ValidationContext<object>(editContext.Model);
-            }
-
-            var asyncValidationTask = validator.ValidateAsync(context);
-            editContext.Properties[PendingAsyncValidation] = asyncValidationTask;
-            var validationResults = await asyncValidationTask;
-
-            messages.Clear();
-            foreach (var validationResult in validationResults.Errors)
-            {
-                var fieldIdentifier = ToFieldIdentifier(editContext, validationResult.PropertyName);
-                messages.Add(fieldIdentifier, validationResult.ErrorMessage);
-            }
-
-            editContext.NotifyValidationStateChanged();
-        }
-    }
-
-    private static async Task ValidateField(EditContext editContext,
-        ValidationMessageStore messages,
-        FieldIdentifier fieldIdentifier,
-        IServiceProvider serviceProvider,
-        bool disableAssemblyScanning,
-        IValidator? validator = null)
-    {
-        var properties = new[] { fieldIdentifier.FieldName };
-        var context = new ValidationContext<object>(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
-            
-        validator ??= GetValidatorForModel(serviceProvider, fieldIdentifier.Model, disableAssemblyScanning);
-
-        if (validator is not null)
-        {
-            var validationResults = await validator.ValidateAsync(context);
-
-            messages.Clear(fieldIdentifier);
-            messages.Add(fieldIdentifier, validationResults.Errors.Select(error => error.ErrorMessage));
-
-            editContext.NotifyValidationStateChanged();
-        }
-    }
-
-    private static IValidator? GetValidatorForModel(IServiceProvider serviceProvider, object model, bool disableAssemblyScanning)
-    {
-        var validatorType = typeof(IValidator<>).MakeGenericType(model.GetType());
-        try
-        {
-            if (serviceProvider.GetService(validatorType) is IValidator validator)
-            {
-                return validator;
-            }
-        }
-        catch (Exception)
-        {
-            // ignored
+            editContext.OnValidationRequested += OnValidationRequestedHandler;
+            editContext.OnFieldChanged += OnFieldChangedHandler;
         }
 
-        if (disableAssemblyScanning)
+        private async void OnFieldChangedHandler(object? sender, FieldChangedEventArgs e)
         {
-            return null;
+            await ValidateField(sender, e);
         }
 
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(i => i.FullName is not null && !ScannedAssembly.Contains(i.FullName)))
+        private async void OnValidationRequestedHandler(object? sender, ValidationRequestedEventArgs e)
         {
+            await ValidateModel(sender, e);
+        }
+
+        private async Task ValidateModel(object? sender, ValidationRequestedEventArgs e)
+        {
+            _validator ??= GetValidatorForModel(_serviceProvider, _editContext.Model, _disableAssemblyScanning);
+
+            if (_validator is not null)
+            {
+                ValidationContext<object> context;
+
+                if (_fluentValidationValidator.ValidateOptions is not null)
+                {
+                    context = ValidationContext<object>.CreateWithOptions(_editContext.Model, _fluentValidationValidator.ValidateOptions);
+                }
+                else if (_fluentValidationValidator.Options is not null)
+                {
+                    context = ValidationContext<object>.CreateWithOptions(_editContext.Model, _fluentValidationValidator.Options);
+                }
+                else
+                {
+                    context = new ValidationContext<object>(_editContext.Model);
+                }
+
+                var asyncValidationTask = _validator.ValidateAsync(context);
+                _editContext.Properties[PendingAsyncValidation] = asyncValidationTask;
+                var validationResults = await asyncValidationTask;
+
+                _messages.Clear();
+                foreach (var validationResult in validationResults.Errors)
+                {
+                    var fieldIdentifier = ToFieldIdentifier(_editContext, validationResult.PropertyName);
+                    _messages.Add(fieldIdentifier, validationResult.ErrorMessage);
+                }
+
+                _editContext.NotifyValidationStateChanged();
+            }
+        }
+
+        private async Task ValidateField(object? sender, FieldChangedEventArgs e)
+        {
+            var properties = new[] { e.FieldIdentifier.FieldName };
+            var context = new ValidationContext<object>(e.FieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
+
+            _validator ??= GetValidatorForModel(_serviceProvider, e.FieldIdentifier.Model, _disableAssemblyScanning);
+
+            if (_validator is not null)
+            {
+                var validationResults = await _validator.ValidateAsync(context);
+
+                _messages.Clear(e.FieldIdentifier);
+                _messages.Add(e.FieldIdentifier, validationResults.Errors.Select(error => error.ErrorMessage));
+
+                _editContext.NotifyValidationStateChanged();
+            }
+        }
+
+        private IValidator? GetValidatorForModel(IServiceProvider serviceProvider, object model, bool disableAssemblyScanning)
+        {
+            var validatorType = typeof(IValidator<>).MakeGenericType(model.GetType());
             try
             {
-                AssemblyScanResults.AddRange(FindValidatorsInAssembly(assembly));
+                if (serviceProvider.GetService(validatorType) is IValidator validator)
+                {
+                    return validator;
+                }
             }
             catch (Exception)
             {
                 // ignored
             }
 
-            ScannedAssembly.Add(assembly.FullName!);
-        }
-
-
-        var interfaceValidatorType = typeof(IValidator<>).MakeGenericType(model.GetType());
-        var modelValidatorType = AssemblyScanResults.FirstOrDefault(i => interfaceValidatorType.IsAssignableFrom(i.InterfaceType))?.ValidatorType;
-
-        if (modelValidatorType is null)
-        {
-            return null;
-        }
-
-        return (IValidator)ActivatorUtilities.CreateInstance(serviceProvider, modelValidatorType);
-    }
-
-    private static FieldIdentifier ToFieldIdentifier(in EditContext editContext, in string propertyPath)
-    {
-        // This code is taken from an article by Steve Sanderson (https://blog.stevensanderson.com/2019/09/04/blazor-fluentvalidation/)
-        // all credit goes to him for this code.
-
-        // This method parses property paths like 'SomeProp.MyCollection[123].ChildProp'
-        // and returns a FieldIdentifier which is an (instance, propName) pair. For example,
-        // it would return the pair (SomeProp.MyCollection[123], "ChildProp"). It traverses
-        // as far into the propertyPath as it can go until it finds any null instance.
-
-        var obj = editContext.Model;
-        var nextTokenEnd = propertyPath.IndexOfAny(Separators);
-            
-        // Optimize for a scenario when parsing isn't needed.
-        if (nextTokenEnd < 0)
-        {
-            return new FieldIdentifier(obj, propertyPath);
-        }
-
-        ReadOnlySpan<char> propertyPathAsSpan = propertyPath;
-
-        while (true)
-        {
-            var nextToken = propertyPathAsSpan.Slice(0, nextTokenEnd);
-            propertyPathAsSpan = propertyPathAsSpan.Slice(nextTokenEnd + 1);
-
-            object? newObj;
-            if (nextToken.EndsWith("]"))
+            if (disableAssemblyScanning)
             {
-                // It's an indexer
-                // This code assumes C# conventions (one indexer named Item with one param)
-                nextToken = nextToken.Slice(0, nextToken.Length - 1);
-                var prop = obj.GetType().GetProperty("Item");
+                return null;
+            }
 
-                if (prop is not null)
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(i => i.FullName is not null && !ScannedAssembly.Contains(i.FullName)))
+            {
+                try
                 {
-                    // we've got an Item property
-                    var indexerType = prop.GetIndexParameters()[0].ParameterType;
-                    var indexerValue = Convert.ChangeType(nextToken.ToString(), indexerType);
-                        
-                    newObj = prop.GetValue(obj, new [] { indexerValue });
+                    AssemblyScanResults.AddRange(FindValidatorsInAssembly(assembly));
                 }
-                else
+                catch (Exception)
                 {
-                    // If there is no Item property
-                    // Try to cast the object to array
-                    if (obj is object[] array)
+                    // ignored
+                }
+
+                ScannedAssembly.Add(assembly.FullName!);
+            }
+
+
+            var interfaceValidatorType = typeof(IValidator<>).MakeGenericType(model.GetType());
+            var modelValidatorType = AssemblyScanResults.FirstOrDefault(i => interfaceValidatorType.IsAssignableFrom(i.InterfaceType))?.ValidatorType;
+
+            if (modelValidatorType is null)
+            {
+                return null;
+            }
+
+            return (IValidator)ActivatorUtilities.CreateInstance(serviceProvider, modelValidatorType);
+        }
+
+        private FieldIdentifier ToFieldIdentifier(in EditContext editContext, in string propertyPath)
+        {
+            // This code is taken from an article by Steve Sanderson (https://blog.stevensanderson.com/2019/09/04/blazor-fluentvalidation/)
+            // all credit goes to him for this code.
+
+            // This method parses property paths like 'SomeProp.MyCollection[123].ChildProp'
+            // and returns a FieldIdentifier which is an (instance, propName) pair. For example,
+            // it would return the pair (SomeProp.MyCollection[123], "ChildProp"). It traverses
+            // as far into the propertyPath as it can go until it finds any null instance.
+
+            var obj = editContext.Model;
+            var nextTokenEnd = propertyPath.IndexOfAny(Separators);
+
+            // Optimize for a scenario when parsing isn't needed.
+            if (nextTokenEnd < 0)
+            {
+                return new FieldIdentifier(obj, propertyPath);
+            }
+
+            ReadOnlySpan<char> propertyPathAsSpan = propertyPath;
+
+            while (true)
+            {
+                var nextToken = propertyPathAsSpan.Slice(0, nextTokenEnd);
+                propertyPathAsSpan = propertyPathAsSpan.Slice(nextTokenEnd + 1);
+
+                object? newObj;
+                if (nextToken.EndsWith("]"))
+                {
+                    // It's an indexer
+                    // This code assumes C# conventions (one indexer named Item with one param)
+                    nextToken = nextToken.Slice(0, nextToken.Length - 1);
+                    var prop = obj.GetType().GetProperty("Item");
+
+                    if (prop is not null)
                     {
-                        var indexerValue = int.Parse(nextToken);
-                        newObj = array[indexerValue];
+                        // we've got an Item property
+                        var indexerType = prop.GetIndexParameters()[0].ParameterType;
+                        var indexerValue = Convert.ChangeType(nextToken.ToString(), indexerType);
+
+                        newObj = prop.GetValue(obj, new[] { indexerValue });
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Could not find indexer on object of type {obj.GetType().FullName}.");
+                        // If there is no Item property
+                        // Try to cast the object to array
+                        if (obj is object[] array)
+                        {
+                            var indexerValue = int.Parse(nextToken);
+                            newObj = array[indexerValue];
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Could not find indexer on object of type {obj.GetType().FullName}.");
+                        }
                     }
                 }
-            }
-            else
-            {
-                // It's a regular property
-                var prop = obj.GetType().GetProperty(nextToken.ToString());
-                if (prop == null)
+                else
                 {
-                    throw new InvalidOperationException($"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
+                    // It's a regular property
+                    var prop = obj.GetType().GetProperty(nextToken.ToString());
+                    if (prop == null)
+                    {
+                        throw new InvalidOperationException($"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
+                    }
+                    newObj = prop.GetValue(obj);
                 }
-                newObj = prop.GetValue(obj);
-            }
 
-            if (newObj == null)
-            {
-                // This is as far as we can go
-                return new FieldIdentifier(obj, nextToken.ToString());
-            }
+                if (newObj == null)
+                {
+                    // This is as far as we can go
+                    return new FieldIdentifier(obj, nextToken.ToString());
+                }
 
-            obj = newObj;
-                
-            nextTokenEnd = propertyPathAsSpan.IndexOfAny(Separators);
-            if (nextTokenEnd < 0)
-            {
-                return new FieldIdentifier(obj, propertyPathAsSpan.ToString());
+                obj = newObj;
+
+                nextTokenEnd = propertyPathAsSpan.IndexOfAny(Separators);
+                if (nextTokenEnd < 0)
+                {
+                    return new FieldIdentifier(obj, propertyPathAsSpan.ToString());
+                }
             }
+        }
+
+        public void Dispose()
+        {
+            _messages.Clear();
+            _editContext.OnFieldChanged -= OnFieldChangedHandler;
+            _editContext.OnValidationRequested -= OnValidationRequestedHandler;
+            _editContext.NotifyValidationStateChanged();
         }
     }
 }


### PR DESCRIPTION
Since the event handlers were in static classes, this allowed the event to be subscribed to multiple times causing increasing duplications of error messages.  I found the issue when I was using the TelerikWizard and would fire off form validation, move to another step, and move back to the form again and fire validation again.  It would result in the same error messages piling up each time I left and returned.  This is the fix for that.