### PR TITLE
Implemented a new method `AddValidationResult` in FluentValidationVal…

### DIFF
--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -68,6 +68,7 @@
 </EditForm>
 <br />
 <button @onclick="PartialValidate">Partial Validation</button>
+<button @onclick="AddValidationResult">Add Validation Result</button>
 
 @code {
     private readonly Person _person = new();
@@ -78,4 +79,14 @@
 
     private void PartialValidate() 
         => Console.WriteLine($"Partial validation result : {_fluentValidationValidator?.Validate(options => options.IncludeRuleSets("Names"))}");
+
+    private void AddValidationResult()
+    {
+        _fluentValidationValidator!.AddValidationResult(_person, new FluentValidation.Results.ValidationResult
+            {
+                Errors = new List<FluentValidation.Results.ValidationFailure> {
+                    new FluentValidation.Results.ValidationFailure { PropertyName = "EmailAddress", ErrorMessage = "This email address is taken already"}
+                }
+            });
+    }
 }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -68,6 +68,7 @@
 </EditForm>
 <br />
 <button @onclick="PartialValidate">Partial Validation</button>
+<button @onclick="AddValidationResult">Add Validation Result</button>
 
 @code {
     private readonly Person _person = new();
@@ -83,4 +84,14 @@
 
     private void PartialValidate()
         => Console.WriteLine($"Partial validation result : {_fluentValidationValidator?.Validate(options => options.IncludeRuleSets("Names"))}");
+
+    private void AddValidationResult()
+    {
+        _fluentValidationValidator!.AddValidationResult(_person, new FluentValidation.Results.ValidationResult
+            {
+                Errors = new List<FluentValidation.Results.ValidationFailure> {
+                    new FluentValidation.Results.ValidationFailure { PropertyName = "EmailAddress", ErrorMessage = "This email address is taken already"}
+                }
+            });
+    }
 }


### PR DESCRIPTION
Add manual ValidationResult handling to EditContext

Implemented a new method `AddValidationResult` in FluentValidationValidator that allows manual addition of FluentValidation's ValidationResult errors to the Blazored FluentValidation EditContext. This enables explicit control over the validation state and message display within Blazor forms, particularly useful when integrating custom validation scenarios that are not automatically managed by Blazor's data annotation validators.
