### PR TITLE
Fix inconsistent field-level validation (Fixes #204)

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -86,6 +86,7 @@ public static class EditContextFluentValidationExtensions
         {
             var validationResults = await validator.ValidateAsync(new ValidationContext<object>(editContext.Model, new PropertyChain(), compositeSelector));
             var errorMessages = validationResults.Errors
+                .Where(validationFailure => validationFailure.PropertyName == propertyPath)
                 .Select(validationFailure => validationFailure.ErrorMessage)
                 .Distinct();
 

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -37,20 +37,7 @@ public static class EditContextFluentValidationExtensions
 
         if (validator is not null)
         {
-            ValidationContext<object> context;
-
-            if (fluentValidationValidator.ValidateOptions is not null)
-            {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.ValidateOptions);
-            }
-            else if (fluentValidationValidator.Options is not null)
-            {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.Options);
-            }
-            else
-            {
-                context = new ValidationContext<object>(editContext.Model);
-            }
+            var context = ConstructValidationContext(editContext, fluentValidationValidator);
 
             var asyncValidationTask = validator.ValidateAsync(context);
             editContext.Properties[PendingAsyncValidation] = asyncValidationTask;
@@ -82,20 +69,7 @@ public static class EditContextFluentValidationExtensions
             return;
         }
         
-        ValidationContext<object> context;
-
-        if (fluentValidationValidator.ValidateOptions is not null)
-        {
-            context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.ValidateOptions);
-        }
-        else if (fluentValidationValidator.Options is not null)
-        {
-            context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.Options);
-        }
-        else
-        {
-            context = new ValidationContext<object>(editContext.Model);
-        }
+        var context = ConstructValidationContext(editContext, fluentValidationValidator);
 
         var fluentValidationValidatorSelector = context.Selector;
         var changedPropertySelector = ValidationContext<object>.CreateWithOptions(editContext.Model, strategy =>
@@ -120,6 +94,27 @@ public static class EditContextFluentValidationExtensions
 
             editContext.NotifyValidationStateChanged();
         }
+    }
+
+    private static ValidationContext<object> ConstructValidationContext(EditContext editContext,
+        FluentValidationValidator fluentValidationValidator)
+    {
+        ValidationContext<object> context;
+
+        if (fluentValidationValidator.ValidateOptions is not null)
+        {
+            context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.ValidateOptions);
+        }
+        else if (fluentValidationValidator.Options is not null)
+        {
+            context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.Options);
+        }
+        else
+        {
+            context = new ValidationContext<object>(editContext.Model);
+        }
+
+        return context;
     }
 
     private static IValidator? GetValidatorForModel(IServiceProvider serviceProvider, object model, bool disableAssemblyScanning)

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -44,13 +44,11 @@ public static class EditContextFluentValidationExtensions
 
             if (fluentValidationValidator.ValidateOptions is not null)
             {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model,
-                    fluentValidationValidator.ValidateOptions);
+                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.ValidateOptions);
             }
             else if (fluentValidationValidator.Options is not null)
             {
-                context = ValidationContext<object>.CreateWithOptions(editContext.Model,
-                    fluentValidationValidator.Options);
+                context = ValidationContext<object>.CreateWithOptions(editContext.Model, fluentValidationValidator.Options);
             }
             else
             {
@@ -123,8 +121,8 @@ public static class EditContextFluentValidationExtensions
 
     private class Node
     {
-        public Node? Parent { get; set; }
         public object ModelObject { get; set; }
+        public Node? Parent { get; set; }
         public string? PropertyName { get; set; }
         public int? Index { get; set; }
     }
@@ -246,8 +244,7 @@ public static class EditContextFluentValidationExtensions
             return null;
         }
 
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()
-                     .Where(i => i.FullName is not null && !ScannedAssembly.Contains(i.FullName)))
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(i => i.FullName is not null && !ScannedAssembly.Contains(i.FullName)))
         {
             try
             {
@@ -263,8 +260,7 @@ public static class EditContextFluentValidationExtensions
 
 
         var interfaceValidatorType = typeof(IValidator<>).MakeGenericType(model.GetType());
-        var modelValidatorType = AssemblyScanResults
-            .FirstOrDefault(i => interfaceValidatorType.IsAssignableFrom(i.InterfaceType))?.ValidatorType;
+        var modelValidatorType = AssemblyScanResults.FirstOrDefault(i => interfaceValidatorType.IsAssignableFrom(i.InterfaceType))?.ValidatorType;
 
         if (modelValidatorType is null)
         {
@@ -327,8 +323,7 @@ public static class EditContextFluentValidationExtensions
                     }
                     else
                     {
-                        throw new InvalidOperationException(
-                            $"Could not find indexer on object of type {obj.GetType().FullName}.");
+                        throw new InvalidOperationException($"Could not find indexer on object of type {obj.GetType().FullName}.");
                     }
                 }
             }
@@ -338,8 +333,7 @@ public static class EditContextFluentValidationExtensions
                 var prop = obj.GetType().GetProperty(nextToken.ToString());
                 if (prop == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
+                    throw new InvalidOperationException($"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
                 }
 
                 newObj = prop.GetValue(obj);

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -17,9 +17,6 @@ public static class EditContextFluentValidationExtensions
     {
         ArgumentNullException.ThrowIfNull(editContext, nameof(editContext));
 
-        ValidatorOptions.Global.ValidatorSelectors.CompositeValidatorSelectorFactory =
-            (selectors) => new IntersectingCompositeValidatorSelector(selectors);
-
         var messages = new ValidationMessageStore(editContext);
 
         editContext.OnValidationRequested +=

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -107,7 +107,7 @@ public static class EditContextFluentValidationExtensions
         }).Selector;
         
         var compositeSelector =
-            new IntersectingCompositeValidatorSelector(new IValidatorSelector[] { fluentValidationValidatorSelector, changedPropertySelector });
+            new IntersectingCompositeValidatorSelector(new[] { fluentValidationValidatorSelector, changedPropertySelector });
 
         validator ??= GetValidatorForModel(serviceProvider, editContext.Model, disableAssemblyScanning);
         

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -1,21 +1,31 @@
-﻿using FluentValidation;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation;
 using FluentValidation.Internal;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using System;
 using FluentValidation.Results;
 
 namespace Blazored.FluentValidation;
 
 public class FluentValidationValidator : ComponentBase
 {
-    [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
+    [Inject]
+    private IServiceProvider ServiceProvider { get; set; } = default!;
 
-    [CascadingParameter] private EditContext? CurrentEditContext { get; set; }
+    [CascadingParameter]
+    private EditContext? CurrentEditContext { get; set; }
 
-    [Parameter] public IValidator? Validator { get; set; }
-    [Parameter] public bool DisableAssemblyScanning { get; set; }
-    [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
+    [Parameter]
+    public IValidator? Validator { get; set; }
+
+    [Parameter]
+    public bool DisableAssemblyScanning { get; set; }
+
+    [Parameter]
+    public Action<ValidationStrategy<object>>? Options { get; set; }
+
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
 
     public bool Validate(Action<ValidationStrategy<object>>? options = null)

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -10,13 +10,9 @@ namespace Blazored.FluentValidation;
 public class FluentValidationValidator : ComponentBase
 {
     [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
-
     [CascadingParameter] private EditContext? CurrentEditContext { get; set; }
-
     [Parameter] public IValidator? Validator { get; set; }
-
     [Parameter] public bool DisableAssemblyScanning { get; set; }
-
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
 
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using FluentValidation;
 using FluentValidation.Internal;
 using Microsoft.AspNetCore.Components;

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -11,20 +11,15 @@ namespace Blazored.FluentValidation;
 
 public class FluentValidationValidator : ComponentBase
 {
-    [Inject]
-    private IServiceProvider ServiceProvider { get; set; } = default!;
+    [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
 
-    [CascadingParameter]
-    private EditContext? CurrentEditContext { get; set; }
+    [CascadingParameter] private EditContext? CurrentEditContext { get; set; }
 
-    [Parameter]
-    public IValidator? Validator { get; set; }
+    [Parameter] public IValidator? Validator { get; set; }
 
-    [Parameter]
-    public bool DisableAssemblyScanning { get; set; }
+    [Parameter] public bool DisableAssemblyScanning { get; set; }
 
-    [Parameter]
-    public Action<ValidationStrategy<object>>? Options { get; set; }
+    [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
 
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
 

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -10,7 +10,9 @@ namespace Blazored.FluentValidation;
 public class FluentValidationValidator : ComponentBase
 {
     [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
+
     [CascadingParameter] private EditContext? CurrentEditContext { get; set; }
+
     [Parameter] public IValidator? Validator { get; set; }
     [Parameter] public bool DisableAssemblyScanning { get; set; }
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -14,7 +14,6 @@ public class FluentValidationValidator : ComponentBase
     [Parameter] public IValidator? Validator { get; set; }
     [Parameter] public bool DisableAssemblyScanning { get; set; }
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
-
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
 
     public bool Validate(Action<ValidationStrategy<object>>? options = null)

--- a/src/Blazored.FluentValidation/IntersectingCompositeValidatorSelector.cs
+++ b/src/Blazored.FluentValidation/IntersectingCompositeValidatorSelector.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using FluentValidation.Internal;
+
+namespace Blazored.FluentValidation;
+
+internal class IntersectingCompositeValidatorSelector : IValidatorSelector {
+    private readonly IEnumerable<IValidatorSelector> _selectors;
+
+    public IntersectingCompositeValidatorSelector(IEnumerable<IValidatorSelector> selectors) {
+        _selectors = selectors;
+    }
+
+    public bool CanExecute(IValidationRule rule, string propertyPath, IValidationContext context) {
+        return _selectors.All(s => s.CanExecute(rule, propertyPath, context));
+    }
+}

--- a/src/Blazored.FluentValidation/PropertyPathHelper.cs
+++ b/src/Blazored.FluentValidation/PropertyPathHelper.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Blazored.FluentValidation;
+
+public static class PropertyPathHelper
+{
+    private class Node
+    {
+        public Node? Parent { get; set; }
+        public object ModelObject { get; set; }
+        public string? PropertyName { get; set; }
+        public int? Index { get; set; }
+    }
+
+    public static string ToFluentPropertyPath(EditContext editContext, FieldIdentifier fieldIdentifier)
+    {
+        var nodes = new Stack<Node>();
+        nodes.Push(new Node()
+        {
+            ModelObject = editContext.Model,
+        });
+
+        while (nodes.Any())
+        {
+            var currentNode = nodes.Pop();
+            object? currentModelObject = currentNode.ModelObject;
+
+            if (currentModelObject == fieldIdentifier.Model)
+            {
+                return BuildPropertyPath(currentNode, fieldIdentifier);
+            }
+            
+            var nonPrimitiveProperties = currentModelObject
+                .GetType()
+                .GetProperties()
+                .Where(prop => !prop.PropertyType.IsPrimitive || prop.PropertyType.IsArray);
+
+            foreach (var nonPrimitiveProperty in nonPrimitiveProperties)
+            {
+                var instance = nonPrimitiveProperty.GetValue(currentModelObject);
+
+                if (instance == fieldIdentifier.Model)
+                {
+                    var node = new Node()
+                    {
+                        Parent = currentNode,
+                        PropertyName = nonPrimitiveProperty.Name,
+                        ModelObject = instance
+                    };
+                    
+                    return BuildPropertyPath(node, fieldIdentifier);
+                }
+                
+                if(instance is IEnumerable enumerable)
+                {
+                    var itemIndex = 0;
+                    foreach (var item in enumerable)
+                    {
+                        nodes.Push(new Node()
+                        {
+                            ModelObject = item,
+                            Parent = currentNode,
+                            PropertyName = nonPrimitiveProperty.Name,
+                            Index = itemIndex++
+                        });
+                    }
+                }
+                else if(instance is not null)
+                {
+                    nodes.Push(new Node()
+                    {
+                        ModelObject = instance,
+                        Parent = currentNode,
+                        PropertyName = nonPrimitiveProperty.Name
+                    });
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+    
+    private static string BuildPropertyPath(Node currentNode, FieldIdentifier fieldIdentifier)
+    {
+        var pathParts = new List<string>();
+        pathParts.Add(fieldIdentifier.FieldName);
+        var next = currentNode;
+
+        while (next is not null)
+        {
+            if (!string.IsNullOrEmpty(next.PropertyName))
+            {
+                if (next.Index is not null)
+                {
+                    pathParts.Add($"{next.PropertyName}[{next.Index}]");
+                }
+                else
+                {
+                    pathParts.Add(next.PropertyName);
+                }
+            }
+
+            next = next.Parent;
+        }
+
+        pathParts.Reverse();
+
+        return string.Join('.', pathParts);
+    }
+}

--- a/src/Blazored.FluentValidation/PropertyPathHelper.cs
+++ b/src/Blazored.FluentValidation/PropertyPathHelper.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Reflection;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace Blazored.FluentValidation;
@@ -8,7 +9,7 @@ public static class PropertyPathHelper
     private class Node
     {
         public Node? Parent { get; set; }
-        public object ModelObject { get; set; }
+        public object? ModelObject { get; set; }
         public string? PropertyName { get; set; }
         public int? Index { get; set; }
     }
@@ -31,10 +32,9 @@ public static class PropertyPathHelper
                 return BuildPropertyPath(currentNode, fieldIdentifier);
             }
             
-            var nonPrimitiveProperties = currentModelObject
-                .GetType()
+            var nonPrimitiveProperties = currentModelObject?.GetType()
                 .GetProperties()
-                .Where(prop => !prop.PropertyType.IsPrimitive || prop.PropertyType.IsArray);
+                .Where(prop => !prop.PropertyType.IsPrimitive || prop.PropertyType.IsArray) ?? new List<PropertyInfo>();
 
             foreach (var nonPrimitiveProperty in nonPrimitiveProperties)
             {

--- a/src/Blazored.FluentValidation/PropertyPathHelper.cs
+++ b/src/Blazored.FluentValidation/PropertyPathHelper.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Blazored.FluentValidation;
 
-public static class PropertyPathHelper
+internal static class PropertyPathHelper
 {
     private class Node
     {

--- a/src/Blazored.FluentValidation/PropertyPathHelper.cs
+++ b/src/Blazored.FluentValidation/PropertyPathHelper.cs
@@ -24,7 +24,7 @@ public static class PropertyPathHelper
         while (nodes.Any())
         {
             var currentNode = nodes.Pop();
-            object? currentModelObject = currentNode.ModelObject;
+            var currentModelObject = currentNode.ModelObject;
 
             if (currentModelObject == fieldIdentifier.Model)
             {


### PR DESCRIPTION
This fixes a few issues that are causing inconsistent behaviour between field-level and whole-model validation.

See #204 for more context and a demo project

Summary of changes:

* The type of `EditContext.Model` is used to locate a validator for field-level validation if one is not provided
* For field-level validation, the received `FieldIdentifier` is converted to a Fluent property path (eg `Customer.Address[0].Line1`) by searching the `EditContext.Model` instance, and then the validation results at that path are used to determine if the field is valid. The `<FluentValidationValidator>` options are supplied to Fluent, but are combined with an additional restriction so that only rules affecting the changed property are ran (as per the default `MemberNameValidatorSelector` behaviour)
* The configuration of `<FluentValidationValidator>` that is currently used for whole-model validation is also used when validating fields, this means that RuleSets and other configuration work as expected at the field-level.

The above would just mirror the existing whole-model validation for field-level validation, so I think it's a fairly safe change. If a project is using Blazored.FluentValidation then they'll have a validator configured that works for the whole model.

Could I please get your thoughts? I'm looking at this through quite a narrow lense so there may be issues with the proposal that haven't occured to me - it does seem to work okay though.

Resolves #204 
Resolves #188 
Resolves #180

