### PR TITLE
Make full validation result details available (also per field)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,31 @@ The second is when manually validating the model using the `Validate` or `Valida
         => _fluentValidationValidator?.Validate(options => options.IncludeRuleSets("Names"));
 }
 ```
+
+## Access to full `ValidationFailure`
+If you need details about the specifics of a validation result (e.g. its `Severity), you can access the result of the 
+last validation by calling the `GetFailuresFromLastValidation` method on the `FluentValidationValidator` component.
+
+```razor
+<div class="validation-message @GetValidationClass()">
+    <input type="text" @bind="@_person.Name" />
+</div>
+
+@code {
+    private FluentValidationValidator? _fluentValidationValidator;
+
+    private string GetValidationClass() 
+    {
+        var lastResult = _fluentValidationValidator?.GetFailuresFromLastValidation();
+        if (lastResult is null || !lastResult.Any())
+        {
+            return "valid";
+        }
+        if (lastResult.Any(failure => failure.Severity == Severity.Error))
+        {
+            return "invalid";
+        }
+        return "warning";
+    }
+}
+```

--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -14,20 +14,17 @@ public static class EditContextFluentValidationExtensions
     private static readonly List<AssemblyScanResult> AssemblyScanResults = new();
     public const string PendingAsyncValidation = "AsyncValidationTask";
 
-    public static void AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning,
-        IValidator? validator, FluentValidationValidator fluentValidationValidator)
+    public static void AddFluentValidation(this EditContext editContext, IServiceProvider serviceProvider, bool disableAssemblyScanning, IValidator? validator, FluentValidationValidator fluentValidationValidator)
     {
         ArgumentNullException.ThrowIfNull(editContext, nameof(editContext));
 
         var messages = new ValidationMessageStore(editContext);
 
         editContext.OnValidationRequested +=
-            async (sender, _) => await ValidateModel((EditContext)sender!, messages, serviceProvider, disableAssemblyScanning,
-                fluentValidationValidator, validator);
+            async (sender, _) => await ValidateModel((EditContext)sender!, messages, serviceProvider, disableAssemblyScanning, fluentValidationValidator, validator);
 
         editContext.OnFieldChanged +=
-            async (_, eventArgs) =>
-                await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
+            async (_, eventArgs) => await ValidateField(editContext, messages, eventArgs.FieldIdentifier, serviceProvider, disableAssemblyScanning, validator);
     }
 
     private static async Task ValidateModel(EditContext editContext,
@@ -91,7 +88,7 @@ public static class EditContextFluentValidationExtensions
     {
         var properties = new[] { fieldIdentifier.FieldName };
         var context = new ValidationContext<object>(fieldIdentifier.Model, new PropertyChain(), new MemberNameValidatorSelector(properties));
-
+            
         validator ??= GetValidatorForModel(serviceProvider, fieldIdentifier.Model, disableAssemblyScanning);
 
         if (validator is not null)
@@ -163,7 +160,7 @@ public static class EditContextFluentValidationExtensions
 
         var obj = editContext.Model;
         var nextTokenEnd = propertyPath.IndexOfAny(Separators);
-
+            
         // Optimize for a scenario when parsing isn't needed.
         if (nextTokenEnd < 0)
         {
@@ -190,8 +187,8 @@ public static class EditContextFluentValidationExtensions
                     // we've got an Item property
                     var indexerType = prop.GetIndexParameters()[0].ParameterType;
                     var indexerValue = Convert.ChangeType(nextToken.ToString(), indexerType);
-
-                    newObj = prop.GetValue(obj, new[] { indexerValue });
+                        
+                    newObj = prop.GetValue(obj, new [] { indexerValue });
                 }
                 else
                 {
@@ -214,10 +211,8 @@ public static class EditContextFluentValidationExtensions
                 var prop = obj.GetType().GetProperty(nextToken.ToString());
                 if (prop == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
+                    throw new InvalidOperationException($"Could not find property named {nextToken.ToString()} on object of type {obj.GetType().FullName}.");
                 }
-
                 newObj = prop.GetValue(obj);
             }
 
@@ -228,7 +223,7 @@ public static class EditContextFluentValidationExtensions
             }
 
             obj = newObj;
-
+                
             nextTokenEnd = propertyPathAsSpan.IndexOfAny(Separators);
             if (nextTokenEnd < 0)
             {

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -17,6 +17,7 @@ public class FluentValidationValidator : ComponentBase
     [Parameter] public bool DisableAssemblyScanning { get; set; }
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
+    internal Dictionary<FieldIdentifier, List<ValidationFailure>>? LastValidationResult { get; set; }
 
     public bool Validate(Action<ValidationStrategy<object>>? options = null)
     {
@@ -80,5 +81,24 @@ public class FluentValidationValidator : ComponentBase
         }
 
         CurrentEditContext.AddFluentValidation(ServiceProvider, DisableAssemblyScanning, Validator, this);
+    }
+
+    /// <summary>
+    /// Gets the full details of the last validation result, optionally by field.
+    /// </summary>
+    /// <param name="fieldIdentifier">If set, only returns the validation failures pertaining to the given field.</param>
+    /// <returns>Validation failures.</returns>
+    public ValidationFailure[] GetFailuresFromLastValidation(FieldIdentifier? fieldIdentifier = null)
+    {
+        if (LastValidationResult is null)
+            return Array.Empty<ValidationFailure>();
+
+        if (fieldIdentifier is null)
+            return LastValidationResult.Values.SelectMany(f => f).ToArray();
+        
+        if (!LastValidationResult.TryGetValue(fieldIdentifier.Value, out var failures))
+             return Array.Empty<ValidationFailure>();
+        
+        return failures.ToArray();
     }
 }


### PR DESCRIPTION
It looks like this was once possible (see #75 ). I think the simplest way to add this is to just make the `ValidationFailure`s available, so if anyone needs anything else from it (not just Severity) they can.

The approach is easy, I just save the latest validation run for a `FluentValidationValidator` and made a method to easily access it (`GetFailuresFromLastValidation`).

I tried to follow the style as well as I could, and I added a documentation paragraph about it, which I can remove if that's not desired.

Closes #75 