### PR TITLE
Addresses an issue with collection expressions in C# 12

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -199,6 +199,16 @@ public static class EditContextFluentValidationExtensions
                         var indexerValue = int.Parse(nextToken);
                         newObj = array[indexerValue];
                     }
+                    else if (obj is IReadOnlyList<object> readOnlyList)
+                    {
+                        // Addresses an issue with collection expressions in C# 12 regarding IReadOnlyList:
+                        // Generates a <>z__ReadOnlyArray which:
+                        // - lacks an Item property, and
+                        // - cannot be cast to object[] successfully.
+                        // This workaround accesses elements directly using an indexer.
+                        var indexerValue = int.Parse(nextToken);
+                        newObj = readOnlyList[indexerValue];
+                    }
                     else
                     {
                         throw new InvalidOperationException($"Could not find indexer on object of type {obj.GetType().FullName}.");


### PR DESCRIPTION
We have identified an issue with Blazored/FluentValidation following the migration to .NET 8.0 and C# 12. Since we work with Fluxor, all our data is immutable. Moreover, we use the IReadOnlyList<> interface for lists throughout.

With the new C# 12 syntax for list initialization, a "standard" list/array is no longer created; instead, a type named "<>z__ReadOnlyArray" is generated. This new type neither possesses an Item property nor can it be converted into an object array. The code in the `ToFieldIdentifier` method within the `EditContextFluentValidationExtensions` class throws an exception as a result.

The following example demonstrates the problem (Note: the code must be compiled with C# 12, and we have tested with Visual Studio 17.9.0):

```
List<string> list = ["1", "2"];
IReadOnlyList<string> readonlyList = ["1", "2"];

var listHasItemProperty = list.GetType().GetProperties().Any(x => x.Name == "Item");
var readOnlyListHasItemProperty = readonlyList.GetType().GetProperties().Any(x => x.Name == "Item");

Console.WriteLine(listHasItemProperty); // True
Console.WriteLine(readOnlyListHasItemProperty); // False

var objects = readonlyList as object[];
Console.WriteLine(objects != null); // False
```

This pull request makes the code compatible again with IReadOnlyList and features from C# 12. We request a swift integration and release of a new Nuget package, as our validation currently does not work.

Thank you for your assistance.