### PR TITLE
Add Net8 target to BlazorServer, SharedModels. Bump FluentValidation to 11.9.2

### DIFF
--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
+++ b/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Shared/SharedModels/SharedModels.csproj
+++ b/samples/Shared/SharedModels/SharedModels.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Blazored.FluentValidation/Blazored.FluentValidation.csproj
+++ b/src/Blazored.FluentValidation/Blazored.FluentValidation.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation" Version="11.9.1" />
+		<PackageReference Include="FluentValidation" Version="11.9.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/tests/Blazored.FluentValidation.Tests/Blazored.FluentValidation.Tests.csproj
+++ b/tests/Blazored.FluentValidation.Tests/Blazored.FluentValidation.Tests.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="bunit" Version="1.28.9" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="FluentValidation" Version="11.9.1" />
+		<PackageReference Include="FluentValidation" Version="11.9.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Apply the net8 target to all projects.
- Bump `FluentValidation` from 11.9.1 to 11.9.2

Relates to #228