### PR TITLE
Build: Upgrade actions to v4. Run tests on pr workflow.

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,6 +10,7 @@ env:
     NETCORE_VERSION: '8.0.x'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: true
+    DOTNET_CONSOLE_ANSI_COLOR: true
     PROJECT_NAME: FluentValidation
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     NUGET_FEED: https://api.nuget.org/v3/index.json
@@ -21,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup .NET Core ${{ env.NETCORE_VERSION }}
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.NETCORE_VERSION }}
       env:
@@ -41,10 +42,10 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.NETCORE_VERSION }}
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,16 +7,20 @@ on:
 env:
     PROJECT_NAME: Blazored.FluentValidation
     NETCORE_VERSION: '8.0.x'
+    DOTNET_CONSOLE_ANSI_COLOR: true
+    #ref https://github.com/dotnet/command-line-api/issues/1710
+    DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+    TERM: xterm
 
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setting up .NET SDK ${{ env.NETCORE_VERSION }}...
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.NETCORE_VERSION }}
 
@@ -25,3 +29,6 @@ jobs:
 
     - name: Building project...
       run: dotnet build --configuration Release --no-restore src/$PROJECT_NAME/$PROJECT_NAME.csproj
+
+    - name: Running tests...
+      run: dotnet test 


### PR DESCRIPTION
- v2 tasks are deprecated, replaced with v4
- Run unit tests in the PR workflow.

Relates to https://github.com/Blazored/FluentValidation/pull/218

As described in there, two tests fail running against `Validate` (not ValidateAsync) due to `LastValidationResult` not being populed when queried.  