### PR TITLE
Add option to configure ValidationContext

### DIFF
--- a/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
+++ b/src/Blazored.FluentValidation/EditContextFluentValidationExtensions.cs
@@ -129,6 +129,8 @@ public static class EditContextFluentValidationExtensions
             context = new ValidationContext<object>(editContext.Model);
         }
 
+        fluentValidationValidator.ConfigureContext?.Invoke(context);
+
         return context;
     }
 

--- a/src/Blazored.FluentValidation/FluentValidationsValidator.cs
+++ b/src/Blazored.FluentValidation/FluentValidationsValidator.cs
@@ -17,6 +17,7 @@ public class FluentValidationValidator : ComponentBase
     [Parameter] public IValidator? Validator { get; set; }
     [Parameter] public bool DisableAssemblyScanning { get; set; }
     [Parameter] public Action<ValidationStrategy<object>>? Options { get; set; }
+    [Parameter] public Action<ValidationContext<object>>? ConfigureContext { get; set; }
     internal Action<ValidationStrategy<object>>? ValidateOptions { get; set; }
     internal Dictionary<FieldIdentifier, List<ValidationFailure>>? LastValidationResult { get; set; }
 

--- a/tests/Blazored.FluentValidation.Tests/Model/Address.cs
+++ b/tests/Blazored.FluentValidation.Tests/Model/Address.cs
@@ -11,6 +11,7 @@
 
     public class AddressValidator : AbstractValidator<Address>
     {
+        public const string IgnorePostcodeFlag = "IgnorePostcode";
         public const string Line1Required = "You must enter Line 1";
         public const string TownRequired = "You must enter a town";
         public const string CountyRequired = "You must enter a county";
@@ -21,7 +22,11 @@
             RuleFor(p => p.Line1).NotEmpty().WithMessage(Line1Required);
             RuleFor(p => p.Town).NotEmpty().WithMessage(TownRequired);
             RuleFor(p => p.County).NotEmpty().WithMessage(CountyRequired);
-            RuleFor(p => p.Postcode).NotEmpty().WithMessage(PostcodeRequired);
+            RuleFor(p => p.Postcode)
+                .NotEmpty().WithMessage(PostcodeRequired)
+                .When((_, ctx) =>
+                    !ctx.RootContextData.TryGetValue(IgnorePostcodeFlag, out var ignorePostcode)
+                    || ignorePostcode is false);
         }
     }
 }

--- a/tests/Blazored.FluentValidation.Tests/ParamValidationContext/Component.razor
+++ b/tests/Blazored.FluentValidation.Tests/ParamValidationContext/Component.razor
@@ -1,0 +1,48 @@
+@* Needs to be in different namespace than Blazored.FluentValidation.*. Otherwise ValidationContext cannot be resolved in .net8*@
+@namespace BlazoredFluentValidation.Tests.ParamValidationContext
+<EditForm
+    Model="@_address"
+    OnValidSubmit="ValidSubmit"
+    OnInvalidSubmit="InvalidSubmit">
+
+    <FluentValidationValidator ConfigureContext="@(ctx => SetContextData(ctx.RootContextData))"/>
+    <ValidationSummary/>
+
+    <p>
+        <label>Address Line 1: </label>
+        <InputText name="@nameof(_address.Line1)" @bind-Value="@_address.Line1"/>
+    </p>
+    
+    <p>
+        <label>Town: </label>
+        <InputText name="@nameof(_address.Town)" @bind-Value="@_address.Town"/>
+    </p>
+
+    <p>
+        <label>County: </label>
+        <InputText name="@nameof(_address.County)" @bind-Value="@_address.County"/>
+    </p>
+
+    <p>
+        <label>Postcode: </label>
+        <InputText name="@nameof(_address.Postcode)" @bind-Value="@_address.Postcode"/>
+    </p>
+    <button type="submit">Save</button>
+</EditForm>
+
+@code {
+    private readonly Address _address = new();
+    internal readonly Dictionary<string, object> ContextData = new(); // Internal to be used in tests to control component behavior
+    internal ValidationResultType? SubmitResult { get; set; } = ValidationResultType.Valid;
+
+    private void ValidSubmit() => SubmitResult = ValidationResultType.Valid;
+    private void InvalidSubmit() => SubmitResult = ValidationResultType.Error;
+
+    private void SetContextData(IDictionary<string, object> rootContextData)
+    {
+        foreach (var item in ContextData)
+        {
+            rootContextData[item.Key] = item.Value;
+        }
+    }
+}

--- a/tests/Blazored.FluentValidation.Tests/ParamValidationContext/Tests.cs
+++ b/tests/Blazored.FluentValidation.Tests/ParamValidationContext/Tests.cs
@@ -1,0 +1,79 @@
+using Blazored.FluentValidation.Tests.Model;
+using BlazoredFluentValidation.Tests.ParamValidationContext;
+using static Blazored.FluentValidation.Tests.Model.AddressValidator;
+
+namespace Blazored.FluentValidation.Tests.ParamValidationContext;
+
+public class Tests : TestContext
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void Validate_PostcodeEmptyAndIgnorePostcodeContextNotSet_InvalidSubmit()
+    {
+        // Arrange
+        var cut = RenderComponent<Component>();
+        var address = _fixture.ValidAddress();
+        address.Postcode = "";
+        // Act
+        FillForm(cut, address);
+        cut.Find("button").Click();
+
+        // Assert
+        cut.Instance.SubmitResult.Should().Be(ValidationResultType.Error);
+    }
+
+
+    [Fact]
+    public void Validate_PostcodeEmptyAndIgnorePostcodeContextFalse_InvalidSubmit()
+    {
+        // Arrange
+        var cut = RenderComponent<Component>();
+        var address = _fixture.ValidAddress();
+        address.Postcode = "";
+        cut.Instance.ContextData.Add(IgnorePostcodeFlag, false);
+
+        // Act
+        FillForm(cut, address);
+        cut.Find("button").Click();
+
+        // Assert
+        cut.Instance.SubmitResult.Should().Be(ValidationResultType.Error);
+    }
+
+    [Fact]
+    public void Validate_PostcodeEmptyAndIgnorePostcodeContextTrue_ValidSubmit()
+    {
+        // Arrange
+        var cut = RenderComponent<Component>();
+        var address = _fixture.ValidAddress();
+        address.Postcode = "";
+        cut.Instance.ContextData.Add(IgnorePostcodeFlag, true);
+
+        // Act
+        FillForm(cut, address);
+        cut.Find("button").Click();
+        cut.WaitForState(() => cut.Instance.SubmitResult == ValidationResultType.Valid);
+        // Assert
+        cut.Instance.SubmitResult.Should().Be(ValidationResultType.Valid);
+    }
+
+    private static void FillForm(IRenderedComponent<Component> cut, Address address)
+    {
+        cut.Find($"input[name={nameof(Address.Line1)}]").Change(address.Line1);
+        cut.Find($"input[name={nameof(Address.Town)}]").Change(address.Town);
+        cut.Find($"input[name={nameof(Address.County)}]").Change(address.County);
+        cut.Find($"input[name={nameof(Address.Postcode)}]").Change(address.Postcode);
+    }
+
+    private class Fixture
+    {
+        public Address ValidAddress() => new()
+        {
+            Line1 = "123 Main St",
+            Town = "Springfield",
+            Postcode = "12345",
+            County = "Real"
+        };
+    }
+}


### PR DESCRIPTION
### **Description**  
This PR adds a new `ConfigureContext` parameter to `FluentValidationValidator`. This parameter allows users to pass an `Action` to modify the `ValidationContext` before it is passed to FluentValidation validators.
This solves the issue in #183, also addressed in #156, but instead of just allowing you to set RootContextData, it provides more robust access to ValidationContext configuration.

### **Why is this needed?**  
Currently, Blazored.FluentValidation does not provide a way to customize the `ValidationContext` used when validating a model. FluentValidation provides powerful context features, that Blazor users could make use of.

### **Why is this better than just allowing `RootContextData`?**  
- `RootContextData` is static per validation execution, while `ConfigureContext` allows for **dynamic** modifications.  
- FluentValidation's `ValidationContext<T>` contains more than just `RootContextData`—it also allows setting a **custom selector** or  defining a **property chain**.  
- More flexibility for complex validation scenarios where `RootContextData` alone would be insufficient.  

### **Example Usage**  
```razor
<FluentValidationValidator ConfigureContext="@(ctx => ctx.RootContextData["UserRole"] = userRole)" />
```
This ensures that validators can access `UserRole` dynamically during validation. 

Unit tests of this feature are also included in the PR.